### PR TITLE
perf: replace hashmap with ahashmap for faster hash computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +32,12 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "faststr"
@@ -40,14 +59,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "metainfo"
-version = "0.7.5"
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "metainfo"
+version = "0.7.6"
+dependencies = [
+ "ahash",
  "faststr",
  "fxhash",
  "paste",
  "tokio",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "paste"
@@ -62,10 +105,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "tokio"
@@ -77,6 +149,24 @@ dependencies = [
  "pin-project-lite",
  "windows-sys",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -143,3 +233,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metainfo"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Transmissing metainfo across components."
@@ -15,6 +15,7 @@ categories = ["accessibility", "rust-patterns", "concurrency"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+ahash = "0.8"
 faststr = "0.2"
 fxhash = "0.2"
 paste = "1"

--- a/src/backward.rs
+++ b/src/backward.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use faststr::FastStr;
 
 pub trait Backward {
@@ -7,8 +6,8 @@ pub trait Backward {
     fn get_backward_transient<K: AsRef<str>>(&self, key: K) -> Option<FastStr>;
     fn get_backward_downstream<K: AsRef<str>>(&self, key: K) -> Option<FastStr>;
 
-    fn get_all_backward_transients(&self) -> Option<&HashMap<FastStr, FastStr>>;
-    fn get_all_backward_downstreams(&self) -> Option<&HashMap<FastStr, FastStr>>;
+    fn get_all_backward_transients(&self) -> Option<&AHashMap<FastStr, FastStr>>;
+    fn get_all_backward_downstreams(&self) -> Option<&AHashMap<FastStr, FastStr>>;
 
     fn set_backward_transient<K: Into<FastStr>, V: Into<FastStr>>(&mut self, key: K, value: V);
     fn set_backward_downstream<K: Into<FastStr>, V: Into<FastStr>>(&mut self, key: K, value: V);

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
-
 use faststr::FastStr;
+
+use crate::AHashMap;
 
 pub trait Forward {
     fn get_persistent<K: AsRef<str>>(&self, key: K) -> Option<FastStr>;
     fn get_transient<K: AsRef<str>>(&self, key: K) -> Option<FastStr>;
     fn get_upstream<K: AsRef<str>>(&self, key: K) -> Option<FastStr>;
 
-    fn get_all_persistents(&self) -> Option<&HashMap<FastStr, FastStr>>;
-    fn get_all_transients(&self) -> Option<&HashMap<FastStr, FastStr>>;
-    fn get_all_upstreams(&self) -> Option<&HashMap<FastStr, FastStr>>;
+    fn get_all_persistents(&self) -> Option<&AHashMap<FastStr, FastStr>>;
+    fn get_all_transients(&self) -> Option<&AHashMap<FastStr, FastStr>>;
+    fn get_all_upstreams(&self) -> Option<&AHashMap<FastStr, FastStr>>;
 
     fn set_persistent<K: Into<FastStr>, V: Into<FastStr>>(&mut self, key: K, value: V);
     fn set_transient<K: Into<FastStr>, V: Into<FastStr>>(&mut self, key: K, value: V);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use faststr::FastStr;
 use paste::paste;
 
@@ -14,7 +13,7 @@ macro_rules! set_impl {
                 value: V,
             ) {
                 if self.$name.is_none() {
-                    self.$name = Some(HashMap::with_capacity(DEFAULT_CAPACITY));
+                    self.$name = Some(AHashMap::with_capacity(DEFAULT_CAPACITY));
                 }
                 self.$name.as_mut().unwrap().insert(key.into(), value.into());
             }
@@ -56,7 +55,7 @@ macro_rules! get_impl {
 macro_rules! get_all_impl {
     ($name:ident) => {
         paste! {
-            pub fn [<get_all_ $name s>](&self) -> Option<&HashMap<FastStr, FastStr>> {
+            pub fn [<get_all_ $name s>](&self) -> Option<&AHashMap<FastStr, FastStr>> {
                 self.$name.as_ref()
             }
         }
@@ -65,10 +64,10 @@ macro_rules! get_all_impl {
 
 #[derive(Debug, Default, Clone)]
 pub struct Node {
-    persistent: Option<HashMap<FastStr, FastStr>>,
-    transient: Option<HashMap<FastStr, FastStr>>,
+    persistent: Option<AHashMap<FastStr, FastStr>>,
+    transient: Option<AHashMap<FastStr, FastStr>>,
     // this is called stale because upstream and downstream all use this.
-    stale: Option<HashMap<FastStr, FastStr>>,
+    stale: Option<AHashMap<FastStr, FastStr>>,
 }
 
 impl Node {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use std::{fmt, sync::Arc};
 use ahash::AHashMap;
 use faststr::FastStr;
 pub use faststr_map::FastStrMap;
-use fxhash::FxHashMap;
 use kv::Node;
 use paste::paste;
 pub use type_map::TypeMap;
@@ -67,8 +66,8 @@ pub struct MetaInfo {
     /// we search it in the parent scope.
     parent: Option<Arc<MetaInfo>>,
     tmap: Option<TypeMap>,
-    smap: Option<FxHashMap<FastStr, FastStr>>, // for str k-v
-    faststr_tmap: Option<FastStrMap>,          // for newtype wrapper of FastStr
+    smap: Option<AHashMap<FastStr, FastStr>>, // for str k-v
+    faststr_tmap: Option<FastStrMap>,         // for newtype wrapper of FastStr
 
     /// for information transport through client and server.
     /// e.g. RPC
@@ -147,9 +146,7 @@ impl MetaInfo {
     #[inline]
     pub fn insert_string(&mut self, key: FastStr, val: FastStr) {
         self.smap
-            .get_or_insert_with(|| {
-                FxHashMap::with_capacity_and_hasher(DEFAULT_MAP_SIZE, Default::default())
-            })
+            .get_or_insert_with(|| AHashMap::with_capacity(DEFAULT_MAP_SIZE))
             .insert(key, val);
     }
 
@@ -295,9 +292,7 @@ impl MetaInfo {
 
         if let Some(smap) = other.smap {
             self.smap
-                .get_or_insert_with(|| {
-                    FxHashMap::with_capacity_and_hasher(DEFAULT_MAP_SIZE, Default::default())
-                })
+                .get_or_insert_with(|| AHashMap::with_capacity(DEFAULT_MAP_SIZE))
                 .extend(smap);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 mod faststr_map;
 mod type_map;
 
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{fmt, sync::Arc};
 
+use ahash::AHashMap;
 use faststr::FastStr;
 pub use faststr_map::FastStrMap;
 use fxhash::FxHashMap;
@@ -12,7 +13,6 @@ pub use type_map::TypeMap;
 
 pub mod backward;
 pub mod forward;
-
 pub use backward::Backward;
 pub use forward::Forward;
 
@@ -395,21 +395,21 @@ impl forward::Forward for MetaInfo {
     del_impl!(transient, forward, transient);
     del_impl!(upstream, forward, stale);
 
-    fn get_all_persistents(&self) -> Option<&HashMap<FastStr, FastStr>> {
+    fn get_all_persistents(&self) -> Option<&AHashMap<FastStr, FastStr>> {
         match self.forward_node.as_ref() {
             Some(node) => node.get_all_persistents(),
             None => None,
         }
     }
 
-    fn get_all_transients(&self) -> Option<&HashMap<FastStr, FastStr>> {
+    fn get_all_transients(&self) -> Option<&AHashMap<FastStr, FastStr>> {
         match self.forward_node.as_ref() {
             Some(node) => node.get_all_transients(),
             None => None,
         }
     }
 
-    fn get_all_upstreams(&self) -> Option<&HashMap<FastStr, FastStr>> {
+    fn get_all_upstreams(&self) -> Option<&AHashMap<FastStr, FastStr>> {
         match self.forward_node.as_ref() {
             Some(node) => node.get_all_stales(),
             None => None,
@@ -471,14 +471,14 @@ impl backward::Backward for MetaInfo {
     del_impl!(backward_transient, backward, transient);
     del_impl!(backward_downstream, backward, stale);
 
-    fn get_all_backward_transients(&self) -> Option<&HashMap<FastStr, FastStr>> {
+    fn get_all_backward_transients(&self) -> Option<&AHashMap<FastStr, FastStr>> {
         match self.backward_node.as_ref() {
             Some(node) => node.get_all_transients(),
             None => None,
         }
     }
 
-    fn get_all_backward_downstreams(&self) -> Option<&HashMap<FastStr, FastStr>> {
+    fn get_all_backward_downstreams(&self) -> Option<&AHashMap<FastStr, FastStr>> {
         match self.backward_node.as_ref() {
             Some(node) => node.get_all_stales(),
             None => None,


### PR DESCRIPTION
## Motivation

for the object of faster hash computation of hashmap, which is used in MetaInfo for rpc call

## Solution

replacing hashmap with ahashmap for string kvs in Node struct of MetaInfo for rpc call
