### PR TITLE
perf: reuse hashmap resource in cross-service metainfo node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "metainfo"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "ahash",
  "faststr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metainfo"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Transmissing metainfo across components."

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -112,6 +112,20 @@ impl Node {
             }
         }
     }
+
+    pub fn clear(&mut self) {
+        if let Some(v) = self.persistent.as_mut() {
+            v.clear();
+        }
+
+        if let Some(v) = self.transient.as_mut() {
+            v.clear();
+        }
+
+        if let Some(v) = self.stale.as_mut() {
+            v.clear();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,8 +276,12 @@ impl MetaInfo {
         if let Some(faststr_tmap) = self.faststr_tmap.as_mut() {
             faststr_tmap.clear()
         }
-        self.forward_node = None;
-        self.backward_node = None;
+        if let Some(forward_node) = self.forward_node.as_mut() {
+            forward_node.clear()
+        }
+        if let Some(backward_node) = self.backward_node.as_mut() {
+            backward_node.clear()
+        }
     }
 
     /// Extends self with the items from another `MetaInfo`.


### PR DESCRIPTION
## Motivation

In the design of connection resource reuse, we observed that for each new request using a reused connection, the framework side still incurs some memory allocation for data structures. Specifically, during the decoding of each request, there is behavior associated with the hashmap's `**reserve_rehash**`, leading us to infer that certain data structures do not retain their memory space after the request is completed.

Upon investigation, we found that at the end of each request, the cleanup of the `**metainfo**` node for cross-service does not use the hashmap's `**clear**` method. Instead, it is directly set to `**None**`. This causes the connection resource to regenerate a default hashmap, i.e., an empty hashmap, for the next request. Therefore, during the `**insert**` operation, frequent `**reserve_rehash**` operations occur due to the lack of reserved memory, resulting in a certain computational cost.

## Solution

To achieve connection resource reuse, when cleaning up the specific data within the current connection resource for each request, we preserve the memory space for all underlying data structures. In this optimization, we primarily focus on preserving memory for the data structures used in the cross-service `**metainfo**` transfer. The specific approach involves implementing a `**clear**` method for the `**Node**` type, which calls the `**clear**` method on the encapsulated hashmap to perform data cleanup, abandoning the practice of directly setting the `**Node**` structure to `**None**`.
